### PR TITLE
Limit tensorflow-datasets dependency to <4.0.0, as its SubwordTextEncoder was deprecated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md", "r") as fh:
 
 requirements = [
     "tensorflow>=2.3.0",
-    "tensorflow-datasets>=3.2.1",
+    "tensorflow-datasets>=3.2.1,<4.0.0",
     "tensorflow-addons>=0.10.0",
     "setuptools>=47.1.1",
     "librosa>=0.7.2",


### PR DESCRIPTION
It's still included, but was moved to `tfds.deprecated.text.SubwordTextEncoder` (https://www.tensorflow.org/datasets/api_docs/python/tfds/deprecated/text/SubwordTextEncoder). Alternatively, the code could be updated to use that API.