### PR TITLE
Update train_conformer.py

### DIFF
--- a/examples/conformer/train_conformer.py
+++ b/examples/conformer/train_conformer.py
@@ -113,9 +113,9 @@ with conformer_trainer.strategy.scope():
     optimizer_config = config.learning_config.optimizer_config
     optimizer = tf.keras.optimizers.Adam(
         TransformerSchedule(
-            d_model=config.model_config["dmodel"],
+            d_model=config.model_config["encoder_dmodel"],
             warmup_steps=optimizer_config["warmup_steps"],
-            max_lr=(0.05 / math.sqrt(config.model_config["dmodel"]))
+            max_lr=(0.05 / math.sqrt(config.model_config["encoder_dmodel"]))
         ),
         beta_1=optimizer_config["beta1"],
         beta_2=optimizer_config["beta2"],


### PR DESCRIPTION
`dmodel`is renamed to `encoder_dmodel` in the new config and lines 116 and 118 lead to `key error`. Just fixed it.