### PR TITLE
Transducer Beam Search V2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ requirements = [
 
 setuptools.setup(
     name="TensorFlowASR",
-    version="0.6.2",
+    version="0.6.3",
     author="Huy Le Nguyen",
     author_email="nlhuy.cs.16@gmail.com",
     description="Almost State-of-the-art Automatic Speech Recognition using Tensorflow 2",

--- a/tensorflow_asr/datasets/asr_dataset.py
+++ b/tensorflow_asr/datasets/asr_dataset.py
@@ -238,9 +238,9 @@ class ASRSliceDataset(ASRDataset):
 
 
 class ASRTFRecordTestDataset(ASRTFRecordDataset):
-    def preprocess(self, path, transcript):
+    def preprocess(self, path, audio, transcript):
         with tf.device("/CPU:0"):
-            signal = read_raw_audio(path.decode("utf-8"), self.speech_featurizer.sample_rate)
+            signal = read_raw_audio(audio, self.speech_featurizer.sample_rate)
 
             features = self.speech_featurizer.extract(signal)
             features = tf.convert_to_tensor(features, tf.float32)
@@ -262,8 +262,8 @@ class ASRTFRecordTestDataset(ASRTFRecordDataset):
 
         return tf.numpy_function(
             self.preprocess,
-            inp=[example["audio"], example["transcript"]],
-            Tout=(tf.string, tf.float32, tf.int32, tf.int32)
+            inp=[example["path"], example["audio"], example["transcript"]],
+            Tout=[tf.string, tf.float32, tf.int32, tf.int32]
         )
 
     def process(self, dataset, batch_size):

--- a/tensorflow_asr/featurizers/text_featurizers.py
+++ b/tensorflow_asr/featurizers/text_featurizers.py
@@ -270,12 +270,11 @@ class SubwordFeaturizer(TextFeaturizer):
                 clear_after_read=False, element_shape=tf.TensorShape([])
             )
 
-            def cond(batch, total, transcripts): return tf.less(batch, total)
+            def cond(batch, total, _): return tf.less(batch, total)
 
             def body(batch, total, transcripts):
                 upoints = self.indices2upoints(indices[batch])
-                _transcript = tf.strings.unicode_encode(upoints, "UTF-8")
-                transcripts = transcripts.write(batch, _transcript)
+                transcripts = transcripts.write(batch, tf.strings.unicode_encode(upoints, "UTF-8"))
                 return batch + 1, total, transcripts
 
             _, _, transcripts = tf.while_loop(cond, body, loop_vars=[batch, total, transcripts])

--- a/tensorflow_asr/models/conformer.py
+++ b/tensorflow_asr/models/conformer.py
@@ -45,8 +45,7 @@ class FFModule(tf.keras.layers.Layer):
             kernel_regularizer=kernel_regularizer,
             bias_regularizer=bias_regularizer
         )
-        self.swish = tf.keras.layers.Activation(
-            tf.keras.activations.swish, name=f"{name}_swish_activation")
+        self.swish = tf.keras.layers.Activation(tf.nn.swish, name=f"{name}_swish_activation")
         self.do1 = tf.keras.layers.Dropout(dropout, name=f"{name}_dropout_1")
         self.ffn2 = tf.keras.layers.Dense(
             input_dim, name=f"{name}_dense_2",
@@ -168,8 +167,7 @@ class ConvModule(tf.keras.layers.Layer):
             gamma_regularizer=kernel_regularizer,
             beta_regularizer=bias_regularizer
         )
-        self.swish = tf.keras.layers.Activation(
-            tf.keras.activations.swish, name=f"{name}_swish_activation")
+        self.swish = tf.keras.layers.Activation(tf.nn.swish, name=f"{name}_swish_activation")
         self.pw_conv_2 = tf.keras.layers.Conv2D(
             filters=input_dim, kernel_size=1, strides=1,
             padding="valid", name=f"{name}_pw_conv_2",

--- a/tensorflow_asr/models/contextnet.py
+++ b/tensorflow_asr/models/contextnet.py
@@ -23,7 +23,7 @@ L2 = tf.keras.regularizers.l2(1e-6)
 
 def get_activation(activation: str = "silu"):
     activation = activation.lower()
-    if activation in ["silu", "swish"]: return tf.nn.silu
+    if activation in ["silu", "swish"]: return tf.nn.swish
     elif activation == "relu": return tf.nn.relu
     elif activation == "linear": return tf.keras.activations.linear
     else: raise ValueError("activation must be either 'silu', 'swish', 'relu' or 'linear'")

--- a/tensorflow_asr/models/transducer.py
+++ b/tensorflow_asr/models/transducer.py
@@ -18,7 +18,7 @@ from typing import Optional
 import tensorflow as tf
 
 from . import Model
-from ..utils.utils import get_rnn, shape_list
+from ..utils.utils import get_rnn, shape_list, count_non_blank
 from ..featurizers.speech_featurizers import SpeechFeaturizer
 from ..featurizers.text_featurizers import TextFeaturizer
 from .layers.embedding import Embedding
@@ -551,7 +551,7 @@ class Transducer(Model):
                              lm: bool = False,
                              parallel_iterations: int = 10,
                              swap_memory: bool = False):
-        with tf.device("/CPU:0"), tf.name_scope(f"{self.name}_beam_search"):
+        with tf.name_scope(f"{self.name}_beam_search"):
             beam_width = tf.cond(
                 tf.less(self.text_featurizer.decoder_config.beam_width, self.text_featurizer.num_classes),
                 true_fn=lambda: self.text_featurizer.decoder_config.beam_width,
@@ -562,22 +562,20 @@ class Transducer(Model):
             def initialize_beam(dynamic=False):
                 return BeamHypothesis(
                     score=tf.TensorArray(
-                        dtype=tf.float32, size=beam_width if not dynamic else 0,
-                        dynamic_size=dynamic, element_shape=tf.TensorShape([]), clear_after_read=False
-                    ),
-                    indices=tf.TensorArray(
-                        dtype=tf.int32, size=beam_width if not dynamic else 0,
-                        dynamic_size=dynamic, element_shape=tf.TensorShape([]), clear_after_read=False
-                    ),
-                    prediction=tf.TensorArray(
-                        dtype=tf.string, size=beam_width if not dynamic else 0, dynamic_size=dynamic,
+                        dtype=tf.float32, size=beam_width if not dynamic else 0, dynamic_size=dynamic,
                         element_shape=tf.TensorShape([]), clear_after_read=False
                     ),
+                    indices=tf.TensorArray(
+                        dtype=tf.int32, size=beam_width if not dynamic else 0, dynamic_size=dynamic,
+                        element_shape=tf.TensorShape([]), clear_after_read=False
+                    ),
+                    prediction=tf.TensorArray(
+                        dtype=tf.int32, size=beam_width if not dynamic else 0, dynamic_size=dynamic,
+                        element_shape=None, clear_after_read=False
+                    ),
                     states=tf.TensorArray(
-                        dtype=tf.float32, size=beam_width if not dynamic else 0,
-                        dynamic_size=dynamic,
-                        element_shape=tf.TensorShape(shape_list(self.predict_net.get_initial_state())),
-                        clear_after_read=False
+                        dtype=tf.float32, size=beam_width if not dynamic else 0, dynamic_size=dynamic,
+                        element_shape=tf.TensorShape(shape_list(self.predict_net.get_initial_state())), clear_after_read=False
                     ),
                 )
 
@@ -585,7 +583,7 @@ class Transducer(Model):
             B = BeamHypothesis(
                 score=B.score.write(0, 0.0),
                 indices=B.indices.write(0, self.text_featurizer.blank),
-                prediction=B.prediction.write(0, ''),
+                prediction=B.prediction.write(0, tf.ones([total], dtype=tf.int32) * self.text_featurizer.blank),
                 states=B.states.write(0, self.predict_net.get_initial_state())
             )
 
@@ -607,11 +605,24 @@ class Transducer(Model):
                 def beam_condition(beam, beam_width, A, A_i, B): return tf.less(beam, beam_width)
 
                 def beam_body(beam, beam_width, A, A_i, B):
-                    y_hat_score, y_hat_score_index = tf.math.top_k(A.score.stack(), k=1)
+                    # get y_hat
+                    y_hat_score, y_hat_score_index = tf.math.top_k(A.score.stack(), k=1, sorted=True)
                     y_hat_score = y_hat_score[0]
                     y_hat_index = tf.gather_nd(A.indices.stack(), y_hat_score_index)
                     y_hat_prediction = tf.gather_nd(A.prediction.stack(), y_hat_score_index)
                     y_hat_states = tf.gather_nd(A.states.stack(), y_hat_score_index)
+
+                    # remove y_hat from A
+                    remain_indices = tf.range(0, tf.shape(A.score.stack())[0], dtype=tf.int32)
+                    remain_indices = tf.gather_nd(remain_indices, tf.where(tf.not_equal(remain_indices, y_hat_score_index[0])))
+                    remain_indices = tf.expand_dims(remain_indices, axis=-1)
+                    A = BeamHypothesis(
+                        score=A.score.unstack(tf.gather_nd(A.score.stack(), remain_indices)),
+                        indices=A.indices.unstack(tf.gather_nd(A.indices.stack(), remain_indices)),
+                        prediction=A.prediction.unstack(tf.gather_nd(A.prediction.stack(), remain_indices)),
+                        states=A.states.unstack(tf.gather_nd(A.states.stack(), remain_indices)),
+                    )
+                    A_i = tf.cond(tf.equal(A_i, 0), true_fn=lambda: A_i, false_fn=lambda: A_i - 1)
 
                     ytu, new_states = self.decoder_inference(encoded=encoded_t, predicted=y_hat_index, states=y_hat_states)
 
@@ -619,35 +630,49 @@ class Transducer(Model):
 
                     def predict_body(pred, A, A_i, B):
                         new_score = y_hat_score + tf.gather_nd(ytu, tf.expand_dims(pred, axis=-1))
+
+                        def true_fn():
+                            return (
+                                B.score.write(beam, new_score),
+                                B.indices.write(beam, y_hat_index),
+                                B.prediction.write(beam, y_hat_prediction),
+                                B.states.write(beam, y_hat_states),
+                                A.score,
+                                A.indices,
+                                A.prediction,
+                                A.states,
+                                A_i,
+                            )
+
+                        def false_fn():
+                            scatter_index = count_non_blank(y_hat_prediction, blank=self.text_featurizer.blank)
+                            updated_prediction = tf.tensor_scatter_nd_update(
+                                y_hat_prediction,
+                                indices=tf.reshape(scatter_index, [1, 1]),
+                                updates=tf.expand_dims(pred, axis=-1)
+                            )
+                            return (
+                                B.score,
+                                B.indices,
+                                B.prediction,
+                                B.states,
+                                A.score.write(A_i, new_score),
+                                A.indices.write(A_i, pred),
+                                A.prediction.write(A_i, updated_prediction),
+                                A.states.write(A_i, new_states),
+                                A_i + 1
+                            )
+
                         b_score, b_indices, b_prediction, b_states, \
                             a_score, a_indices, a_prediction, a_states, A_i = tf.cond(
                                 tf.equal(pred, self.text_featurizer.blank),
-                                true_fn=lambda: (
-                                    B.score.write(beam, new_score),
-                                    B.indices.write(beam, y_hat_index),
-                                    B.prediction.write(beam, y_hat_prediction),
-                                    B.states.write(beam, y_hat_states),
-                                    A.score,
-                                    A.indices,
-                                    A.prediction,
-                                    A.states,
-                                    A_i,
-                                ),
-                                false_fn=lambda: (
-                                    B.score,
-                                    B.indices,
-                                    B.prediction,
-                                    B.states,
-                                    A.score.write(A_i, new_score),
-                                    A.indices.write(A_i, pred),
-                                    A.prediction.write(A_i, tf.strings.reduce_join(
-                                        [y_hat_prediction, tf.strings.format("{}", pred)], separator=" ")),
-                                    A.states.write(A_i, new_states),
-                                    A_i + 1
-                                )
+                                true_fn=true_fn,
+                                false_fn=false_fn
                             )
+
                         B = BeamHypothesis(score=b_score, indices=b_indices, prediction=b_prediction, states=b_states)
                         A = BeamHypothesis(score=a_score, indices=a_indices, prediction=a_prediction, states=a_states)
+
                         return pred + 1, A, A_i, B
 
                     _, A, A_i, B = tf.while_loop(
@@ -674,7 +699,7 @@ class Transducer(Model):
 
             scores = B.score.stack()
             if self.text_featurizer.decoder_config.norm_score:
-                prediction_lengths = tf.strings.length(B.prediction.stack(), unit="UTF8_CHAR")
+                prediction_lengths = count_non_blank(B.prediction.stack(), blank=self.text_featurizer.blank, axis=1)
                 scores /= tf.cast(prediction_lengths, dtype=scores.dtype)
 
             y_hat_score, y_hat_score_index = tf.math.top_k(scores, k=1)
@@ -683,11 +708,7 @@ class Transducer(Model):
             y_hat_prediction = tf.gather_nd(B.prediction.stack(), y_hat_score_index)
             y_hat_states = tf.gather_nd(B.states.stack(), y_hat_score_index)
 
-            return Hypothesis(
-                index=y_hat_index,
-                prediction=tf.strings.to_number(tf.strings.split(y_hat_prediction), out_type=tf.int32),
-                states=y_hat_states
-            )
+            return Hypothesis(index=y_hat_index, prediction=y_hat_prediction, states=y_hat_states)
 
     # -------------------------------- TFLITE -------------------------------------
 

--- a/tensorflow_asr/runners/base_runners.py
+++ b/tensorflow_asr/runners/base_runners.py
@@ -125,7 +125,7 @@ class BaseTrainer(BaseRunner):
 
         self.train_data = train_dataset.create(self.global_batch_size)
         self.train_data_loader = self.strategy.experimental_distribute_dataset(self.train_data)
-        if hasattr(self, "accumulation"):
+        if hasattr(self, "accumulation") and train_dataset.total_steps is not None:
             self.train_steps_per_epoch = train_dataset.total_steps // self.config.accumulation_steps
         else:
             self.train_steps_per_epoch = train_dataset.total_steps

--- a/tensorflow_asr/utils/utils.py
+++ b/tensorflow_asr/utils/utils.py
@@ -153,3 +153,7 @@ def log10(x):
 
 def get_reduced_length(length, reduction_factor):
     return tf.cast(tf.math.ceil(tf.divide(length, tf.cast(reduction_factor, dtype=length.dtype))), dtype=tf.int32)
+
+
+def count_non_blank(tensor: tf.Tensor, blank: int or tf.Tensor = 0, axis=None):
+    return tf.reduce_sum(tf.where(tf.not_equal(tensor, blank), x=tf.ones_like(tensor), y=tf.zeros_like(tensor)), axis=axis)

--- a/tests/streaming_transducer/config.yml
+++ b/tests/streaming_transducer/config.yml
@@ -25,38 +25,42 @@ speech_config:
 
 decoder_config:
   vocabulary: null
-  blank_at_zero: False
-  beam_width: 500
-  lm_config:
-    model_path: null
-    alpha: 2.0
-    beta: 1.0
+  target_vocab_size: 1024
+  max_subword_length: 4
+  blank_at_zero: True
+  beam_width: 5
+  norm_score: True
 
 model_config:
-  name: jasper
-  dense: True
-  first_additional_block_channels: 256
-  first_additional_block_kernels: 11
-  first_additional_block_strides: 2
-  first_additional_block_dilation: 1
-  first_additional_block_dropout: 0.2
-  nsubblocks: 1
-  block_channels: [256, 384, 512, 640, 768]
-  block_kernels: [11, 13, 17, 21, 25]
-  block_dropout: [0.2, 0.2, 0.2, 0.3, 0.3]
-  second_additional_block_channels: 896
-  second_additional_block_kernels: 1
-  second_additional_block_strides: 1
-  second_additional_block_dilation: 2
-  second_additional_block_dropout: 0.4
-  third_additional_block_channels: 1024
-  third_additional_block_kernels: 1
-  third_additional_block_strides: 1
-  third_additional_block_dilation: 1
-  third_additional_block_dropout: 0.4
+  name: streaming_transducer
+  encoder_reductions:
+    0: 3
+    1: 2
+  encoder_dmodel: 320
+  encoder_rnn_type: lstm
+  encoder_rnn_units: 1024
+  encoder_nlayers: 2
+  encoder_layer_norm: True
+  prediction_embed_dim: 320
+  prediction_embed_dropout: 0.0
+  prediction_num_rnns: 2
+  prediction_rnn_units: 1024
+  prediction_rnn_type: lstm
+  prediction_projection_units: 320
+  prediction_layer_norm: True
+  joint_dim: 320
+  joint_activation: tanh
 
 learning_config:
-  augmentations: null
+  augmentations:
+    after:
+      time_masking:
+        num_masks: 10
+        mask_factor: 100
+        p_upperbound: 0.05
+      freq_masking:
+        num_masks: 1
+        mask_factor: 27
 
   dataset_config:
     train_paths:
@@ -74,10 +78,10 @@ learning_config:
       learning_rate: 0.0001
 
   running_config:
-    batch_size: 4
+    batch_size: 2
+    accumulation_steps: 1
     num_epochs: 20
-    accumulation_steps: 8
-    outdir: /mnt/Miscellanea/Models/local/jasper
-    log_interval_steps: 400
-    save_interval_steps: 400
-    eval_interval_steps: 800
+    outdir: /mnt/Miscellanea/Models/local/streaming_transducer
+    log_interval_steps: 300
+    eval_interval_steps: 500
+    save_interval_steps: 1000

--- a/tests/streaming_transducer/test_streaming_transducer.py
+++ b/tests/streaming_transducer/test_streaming_transducer.py
@@ -1,0 +1,57 @@
+# Copyright 2020 Huy Le Nguyen (@usimarit)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+import tensorflow as tf
+
+DEFAULT_YAML = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config.yml")
+
+from tensorflow_asr.configs.config import Config
+from tensorflow_asr.models.streaming_transducer import StreamingTransducer
+from tensorflow_asr.featurizers.text_featurizers import CharFeaturizer
+from tensorflow_asr.featurizers.speech_featurizers import TFSpeechFeaturizer
+
+
+def test_streaming_transducer():
+    config = Config(DEFAULT_YAML, learning=False)
+
+    text_featurizer = CharFeaturizer(config.decoder_config)
+
+    speech_featurizer = TFSpeechFeaturizer(config.speech_config)
+
+    model = StreamingTransducer(vocabulary_size=text_featurizer.num_classes, **config.model_config)
+
+    model._build(speech_featurizer.shape)
+    model.summary(line_length=150)
+
+    model.add_featurizers(speech_featurizer=speech_featurizer, text_featurizer=text_featurizer)
+
+    concrete_func = model.make_tflite_function(timestamp=False).get_concrete_function()
+    converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    converter.experimental_new_converter = True
+    converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
+    converter.convert()
+
+    print("Converted successfully with no timestamp")
+
+    concrete_func = model.make_tflite_function(timestamp=True).get_concrete_function()
+    converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    converter.experimental_new_converter = True
+    converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
+    converter.convert()
+
+    print("Converted successfully with timestamp")


### PR DESCRIPTION
- Remove `tf.string` usage in beam search
- Add missing **remove y_hat from A** after getting the most probable beam in A
- Fix tfrecord test dataset
- Change `tf.nn.silu` and `tf.keras.activation.swish` to `tf.nn.swish`
- Fix `None` total steps when using gradient accumulation
- Add recognize with timestamp for streaming transducer