### PR TITLE
Fix TFLite Conversion and Interpretation

### DIFF
--- a/examples/conformer/tflite_conformer.py
+++ b/examples/conformer/tflite_conformer.py
@@ -54,11 +54,10 @@ conformer.load_weights(args.saved)
 conformer.summary(line_length=150)
 conformer.add_featurizers(speech_featurizer, text_featurizer)
 
-concrete_func = conformer.make_tflite_function(greedy=True).get_concrete_function()
+concrete_func = conformer.make_tflite_function().get_concrete_function()
 converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
 converter.optimizations = [tf.lite.Optimize.DEFAULT]
-converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS,
-                                       tf.lite.OpsSet.SELECT_TF_OPS]
+converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
 tflite_model = converter.convert()
 
 if not os.path.exists(os.path.dirname(args.output)):

--- a/examples/conformer/tflite_subword_conformer.py
+++ b/examples/conformer/tflite_subword_conformer.py
@@ -62,7 +62,7 @@ conformer.load_weights(args.saved, by_name=True)
 conformer.summary(line_length=150)
 conformer.add_featurizers(speech_featurizer, text_featurizer)
 
-concrete_func = conformer.make_tflite_function(greedy=True).get_concrete_function()
+concrete_func = conformer.make_tflite_function().get_concrete_function()
 converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
 converter.experimental_new_converter = True
 converter.optimizations = [tf.lite.Optimize.DEFAULT]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requirements = [
 
 setuptools.setup(
     name="TensorFlowASR",
-    version="0.6.3",
+    version="0.6.4",
     author="Huy Le Nguyen",
     author_email="nlhuy.cs.16@gmail.com",
     description="Almost State-of-the-art Automatic Speech Recognition using Tensorflow 2",

--- a/tensorflow_asr/featurizers/text_featurizers.py
+++ b/tensorflow_asr/featurizers/text_featurizers.py
@@ -168,7 +168,7 @@ class CharFeaturizer(TextFeaturizer):
         with tf.name_scope("indices2upoints"):
             indices = self.normalize_indices(indices)
             upoints = tf.gather_nd(self.upoints, tf.expand_dims(indices, axis=-1))
-            return tf.gather_nd(upoints, tf.where(tf.not_equal(upoints, 0)))
+            return tf.reshape(upoints, shape=[-1])
 
 
 class SubwordFeaturizer(TextFeaturizer):
@@ -275,6 +275,7 @@ class SubwordFeaturizer(TextFeaturizer):
 
             def body(batch, total, transcripts):
                 upoints = self.indices2upoints(indices[batch])
+                upoints = tf.gather_nd(tf.reshape(upoints, shape=[1, -1]), tf.where(tf.not_equal(upoints, 0)))
                 transcripts = transcripts.write(batch, tf.strings.unicode_encode(upoints, "UTF-8"))
                 return batch + 1, total, transcripts
 
@@ -299,7 +300,7 @@ class SubwordFeaturizer(TextFeaturizer):
         with tf.name_scope("indices2upoints"):
             indices = self.normalize_indices(indices)
             upoints = tf.gather_nd(self.upoints, tf.expand_dims(indices, axis=-1))
-            return tf.gather_nd(upoints, tf.where(tf.not_equal(upoints, 0)))
+            return tf.reshape(upoints, shape=[-1])
 
 
 class SentencePieceFeaturizer(TextFeaturizer):
@@ -449,4 +450,4 @@ class SentencePieceFeaturizer(TextFeaturizer):
         with tf.name_scope("indices2upoints"):
             indices = self.normalize_indices(indices)
             upoints = tf.gather_nd(self.upoints, tf.expand_dims(indices, axis=-1))
-            return tf.gather_nd(upoints, tf.where(tf.not_equal(upoints, 0)))
+            return tf.reshape(upoints, shape=[-1])

--- a/tensorflow_asr/featurizers/text_featurizers.py
+++ b/tensorflow_asr/featurizers/text_featurizers.py
@@ -168,7 +168,7 @@ class CharFeaturizer(TextFeaturizer):
         with tf.name_scope("indices2upoints"):
             indices = self.normalize_indices(indices)
             upoints = tf.gather_nd(self.upoints, tf.expand_dims(indices, axis=-1))
-            return tf.reshape(upoints, shape=[-1])
+            return tf.gather_nd(upoints, tf.where(tf.not_equal(upoints, 0)))
 
 
 class SubwordFeaturizer(TextFeaturizer):
@@ -275,7 +275,6 @@ class SubwordFeaturizer(TextFeaturizer):
 
             def body(batch, total, transcripts):
                 upoints = self.indices2upoints(indices[batch])
-                upoints = tf.gather_nd(tf.reshape(upoints, shape=[1, -1]), tf.where(tf.not_equal(upoints, 0)))
                 transcripts = transcripts.write(batch, tf.strings.unicode_encode(upoints, "UTF-8"))
                 return batch + 1, total, transcripts
 
@@ -300,7 +299,7 @@ class SubwordFeaturizer(TextFeaturizer):
         with tf.name_scope("indices2upoints"):
             indices = self.normalize_indices(indices)
             upoints = tf.gather_nd(self.upoints, tf.expand_dims(indices, axis=-1))
-            return tf.reshape(upoints, shape=[-1])
+            return tf.gather_nd(upoints, tf.where(tf.not_equal(upoints, 0)))
 
 
 class SentencePieceFeaturizer(TextFeaturizer):
@@ -450,4 +449,4 @@ class SentencePieceFeaturizer(TextFeaturizer):
         with tf.name_scope("indices2upoints"):
             indices = self.normalize_indices(indices)
             upoints = tf.gather_nd(self.upoints, tf.expand_dims(indices, axis=-1))
-            return tf.reshape(upoints, shape=[-1])
+            return tf.gather_nd(upoints, tf.where(tf.not_equal(upoints, 0)))

--- a/tensorflow_asr/models/transducer.py
+++ b/tensorflow_asr/models/transducer.py
@@ -14,7 +14,6 @@
 """ https://arxiv.org/pdf/1811.06621.pdf """
 
 import collections
-from typing import Optional
 import tensorflow as tf
 
 from . import Model
@@ -285,22 +284,16 @@ class Transducer(Model):
         outputs = self.joint_net([enc, pred], training=training, **kwargs)
         return outputs
 
-    def encoder_inference(self,
-                          features: tf.Tensor,
-                          input_length: Optional[tf.Tensor] = None,
-                          with_batch: Optional[bool] = False):
+    def encoder_inference(self, features: tf.Tensor):
         """Infer function for encoder (or encoders)
 
         Args:
             features (tf.Tensor): features with shape [T, F, C]
-            input_length (tf.Tensor): optional features length with shape []
-            with_batch (bool): indicates whether the features included batch dim or not
 
         Returns:
             tf.Tensor: output of encoders with shape [T, E]
         """
         with tf.name_scope(f"{self.name}_encoder"):
-            if with_batch: return self.encoder(features, training=False)
             outputs = tf.expand_dims(features, axis=0)
             outputs = self.encoder(outputs, training=False)
             return tf.squeeze(outputs, axis=0)
@@ -321,7 +314,7 @@ class Transducer(Model):
             predicted = tf.reshape(predicted, [1, 1])  # [] => [1, 1]
             y, new_states = self.predict_net.recognize(predicted, states)  # [1, 1, P], states
             ytu = tf.nn.log_softmax(self.joint_net([encoded, y], training=False))  # [1, 1, V]
-            ytu = tf.squeeze(ytu, axis=None)  # [1, 1, V] => [V]
+            ytu = tf.reshape(ytu, shape=[-1])  # [1, 1, V] => [V]
             return ytu, new_states
 
     def get_config(self):
@@ -347,7 +340,7 @@ class Transducer(Model):
         Returns:
             tf.Tensor: a batch of decoded transcripts
         """
-        encoded = self.encoder_inference(features, input_length, with_batch=True)
+        encoded = self.encoder(features, training=True)
         return self._perform_greedy_batch(encoded, input_length,
                                           parallel_iterations=parallel_iterations, swap_memory=swap_memory)
 
@@ -445,35 +438,39 @@ class Transducer(Model):
             time = tf.constant(0, dtype=tf.int32)
             total = encoded_length
 
-            prediction = tf.TensorArray(
-                dtype=tf.int32, size=total, dynamic_size=False,
-                clear_after_read=False, element_shape=tf.TensorShape([])
+            hypothesis = Hypothesis(
+                index=predicted,
+                prediction=tf.TensorArray(
+                    dtype=tf.int32, size=total, dynamic_size=False,
+                    clear_after_read=False, element_shape=tf.TensorShape([])
+                ),
+                states=states
             )
 
-            hypothesis = Hypothesis(index=predicted, prediction=prediction, states=states)
+            def condition(_time, _total, _encoded, _hypothesis): return tf.less(_time, _total)
 
-            def condition(time, total, encoded, hypothesis): return tf.less(time, total)
-
-            def body(time, total, encoded, hypothesis):
-                ytu, states = self.decoder_inference(
+            def body(_time, _total, _encoded, _hypothesis):
+                ytu, _states = self.decoder_inference(
                     # avoid using [index] in tflite
-                    encoded=tf.gather_nd(encoded, tf.expand_dims(time, axis=-1)),
-                    predicted=hypothesis.index,
-                    states=hypothesis.states
+                    encoded=tf.gather_nd(_encoded, tf.reshape(_time, shape=[1])),
+                    predicted=_hypothesis.index,
+                    states=_hypothesis.states
                 )
-                predict = tf.argmax(ytu, axis=-1, output_type=tf.int32)  # => argmax []
+                _predict = tf.argmax(ytu, axis=-1, output_type=tf.int32)  # => argmax []
 
-                index, predict, states = tf.cond(
-                    tf.equal(predict, self.text_featurizer.blank),
-                    true_fn=lambda: (hypothesis.index, predict, hypothesis.states),
-                    false_fn=lambda: (predict, predict, states)  # update if the new prediction is a non-blank
-                )
+                # something is wrong with tflite that drop support for tf.cond
+                # def equal_blank_fn(): return _hypothesis.index, _hypothesis.states
+                # def non_equal_blank_fn(): return _predict, _states  # update if the new prediction is a non-blank
+                # _index, _states = tf.cond(tf.equal(_predict, blank), equal_blank_fn, non_equal_blank_fn)
 
-                prediction = hypothesis.prediction.write(time, predict)
+                _equal = tf.equal(_predict, self.text_featurizer.blank)
+                _index = tf.where(_equal, _hypothesis.index, _predict)
+                _states = tf.where(_equal, _hypothesis.states, _states)
 
-                new_hypothesis = Hypothesis(index=index, prediction=prediction, states=states)
+                _prediction = _hypothesis.prediction.write(_time, _predict)
+                _hypothesis = Hypothesis(index=_index, prediction=_prediction, states=_states)
 
-                return time + 1, total, encoded, new_hypothesis
+                return _time + 1, _total, _encoded, _hypothesis
 
             _, _, _, hypothesis = tf.while_loop(
                 condition, body,
@@ -502,7 +499,7 @@ class Transducer(Model):
         Returns:
             tf.Tensor: a batch of decoded transcripts
         """
-        encoded = self.encoder_inference(features, input_length, with_batch=True)
+        encoded = self.encoder(features, training=True)
         return self._perform_beam_search_batch(encoded, input_length, lm,
                                                parallel_iterations=parallel_iterations, swap_memory=swap_memory)
 

--- a/tensorflow_asr/runners/base_runners.py
+++ b/tensorflow_asr/runners/base_runners.py
@@ -149,10 +149,8 @@ class BaseTrainer(BaseRunner):
         with self.strategy.scope():
             self.ckpt = tf.train.Checkpoint(steps=self.steps, **kwargs)
             checkpoint_dir = os.path.join(self.config.outdir, "checkpoints")
-            if not os.path.exists(checkpoint_dir):
-                os.makedirs(checkpoint_dir)
-            self.ckpt_manager = tf.train.CheckpointManager(
-                self.ckpt, checkpoint_dir, max_to_keep=max_to_keep)
+            if not os.path.exists(checkpoint_dir): os.makedirs(checkpoint_dir)
+            self.ckpt_manager = tf.train.CheckpointManager(self.ckpt, checkpoint_dir, max_to_keep=max_to_keep)
 
     def save_checkpoint(self):
         """Save checkpoint."""
@@ -191,9 +189,11 @@ class BaseTrainer(BaseRunner):
         while not self._finished():
             self._train_epoch()
 
-        # save when training is done
+        # save and evaluate when training is done
         self.save_checkpoint()
         self.save_model_weights()
+        self.log_train_metrics()
+        self._eval_epoch()
 
         self.train_progbar.close()
         print("> Finish training")
@@ -221,8 +221,7 @@ class BaseTrainer(BaseRunner):
             self._check_save_interval()
 
             # Print epoch info
-            self.train_progbar.set_description_str(
-                f"[Train] [Epoch {self.epochs}/{self.config.num_epochs}]")
+            self.train_progbar.set_description_str(f"[Train] [Epoch {self.epochs}/{self.config.num_epochs}]")
 
             # Print train info to progress bar
             self._print_train_metrics(self.train_progbar)
@@ -313,40 +312,36 @@ class BaseTrainer(BaseRunner):
 
     # -------------------------------- LOGGING -------------------------------------
 
+    def log_train_metrics(self):
+        self._write_to_tensorboard(self.train_metrics, self.steps, stage="train")
+        """Reset train metrics after save it to tensorboard."""
+        for metric in self.train_metrics.keys():
+            self.train_metrics[metric].reset_states()
+
     def _check_log_interval(self):
         """Save log interval."""
-        if (self.steps % self.config.log_interval_steps == 0) or \
-                (self.total_train_steps and self.steps >= self.total_train_steps):
-            self._write_to_tensorboard(self.train_metrics, self.steps, stage="train")
-            """Reset train metrics after save it to tensorboard."""
-            for metric in self.train_metrics.keys():
-                self.train_metrics[metric].reset_states()
+        if (self.steps.numpy() % self.config.log_interval_steps == 0):
+            self.log_train_metrics()
 
     def _check_save_interval(self):
         """Save log interval."""
-        if (self.steps % self.config.save_interval_steps == 0) or \
-                (self.total_train_steps and self.steps >= self.total_train_steps):
+        if (self.steps.numpy() % self.config.save_interval_steps == 0):
             self.save_checkpoint()
             self.save_model_weights()
 
     def _check_eval_interval(self):
         """Save log interval."""
-        if (self.steps % self.config.eval_interval_steps == 0): # or \
-                # (self.total_train_steps and self.steps >= self.total_train_steps):
+        if (self.steps.numpy() % self.config.eval_interval_steps == 0):
             self._eval_epoch()
 
     # -------------------------------- UTILS -------------------------------------
 
     def _print_train_metrics(self, progbar):
-        result_dict = {}
-        for key, value in self.train_metrics.items():
-            result_dict[f"{key}"] = str(value.result().numpy())
+        result_dict = {key: str(value.result().numpy()) for key, value in self.train_metrics.items()}
         progbar.set_postfix(result_dict)
 
     def _print_eval_metrics(self, progbar):
-        result_dict = {}
-        for key, value in self.eval_metrics.items():
-            result_dict[f"{key}"] = str(value.result().numpy())
+        result_dict = {key: str(value.result().numpy()) for key, value in self.eval_metrics.items()}
         progbar.set_postfix(result_dict)
 
     # -------------------------------- END -------------------------------------

--- a/tests/conformer/test_conformer.py
+++ b/tests/conformer/test_conformer.py
@@ -43,15 +43,43 @@ def test_conformer():
     converter.optimizations = [tf.lite.Optimize.DEFAULT]
     converter.experimental_new_converter = True
     converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
-    converter.convert()
+    tflite = converter.convert()
 
     print("Converted successfully with no timestamp")
 
-    concrete_func = model.make_tflite_function(timestamp=True).get_concrete_function()
-    converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
-    converter.optimizations = [tf.lite.Optimize.DEFAULT]
-    converter.experimental_new_converter = True
-    converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
-    converter.convert()
+    # concrete_func = model.make_tflite_function(timestamp=True).get_concrete_function()
+    # converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
+    # converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    # converter.experimental_new_converter = True
+    # converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
+    # converter.convert()
 
-    print("Converted successfully with timestamp")
+    # print("Converted successfully with timestamp")
+
+    tflitemodel = tf.lite.Interpreter(model_content=tflite)
+    signal = tf.random.normal([4000])
+
+    input_details = tflitemodel.get_input_details()
+    output_details = tflitemodel.get_output_details()
+    tflitemodel.resize_tensor_input(input_details[0]["index"], [4000])
+    tflitemodel.allocate_tensors()
+    tflitemodel.set_tensor(input_details[0]["index"], signal)
+    tflitemodel.set_tensor(
+        input_details[1]["index"],
+        tf.constant(text_featurizer.blank, dtype=tf.int32)
+    )
+    tflitemodel.set_tensor(
+        input_details[2]["index"],
+        tf.zeros(
+            [config.model_config["prediction_num_rnns"], 2, 1, config.model_config["prediction_rnn_units"]],
+            dtype=tf.float32
+        )
+    )
+    tflitemodel.invoke()
+    hyp = tflitemodel.get_tensor(output_details[0]["index"])
+
+    print(hyp)
+
+
+if __name__ == '__main__':
+    test_conformer()

--- a/tests/conformer/test_conformer.py
+++ b/tests/conformer/test_conformer.py
@@ -47,14 +47,14 @@ def test_conformer():
 
     print("Converted successfully with no timestamp")
 
-    # concrete_func = model.make_tflite_function(timestamp=True).get_concrete_function()
-    # converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
-    # converter.optimizations = [tf.lite.Optimize.DEFAULT]
-    # converter.experimental_new_converter = True
-    # converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
-    # converter.convert()
+    concrete_func = model.make_tflite_function(timestamp=True).get_concrete_function()
+    converter = tf.lite.TFLiteConverter.from_concrete_functions([concrete_func])
+    converter.optimizations = [tf.lite.Optimize.DEFAULT]
+    converter.experimental_new_converter = True
+    converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
+    converter.convert()
 
-    # print("Converted successfully with timestamp")
+    print("Converted successfully with timestamp")
 
     tflitemodel = tf.lite.Interpreter(model_content=tflite)
     signal = tf.random.normal([4000])

--- a/tests/contextnet/test_contextnet.py
+++ b/tests/contextnet/test_contextnet.py
@@ -46,7 +46,7 @@ def test_contextnet():
     converter.optimizations = [tf.lite.Optimize.DEFAULT]
     converter.experimental_new_converter = True
     converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
-    converter.convert()
+    tflite = converter.convert()
 
     print("Converted successfully with no timestamp")
 
@@ -58,3 +58,31 @@ def test_contextnet():
     converter.convert()
 
     print("Converted successfully with timestamp")
+
+    tflitemodel = tf.lite.Interpreter(model_content=tflite)
+    signal = tf.random.normal([4000])
+
+    input_details = tflitemodel.get_input_details()
+    output_details = tflitemodel.get_output_details()
+    tflitemodel.resize_tensor_input(input_details[0]["index"], [4000])
+    tflitemodel.allocate_tensors()
+    tflitemodel.set_tensor(input_details[0]["index"], signal)
+    tflitemodel.set_tensor(
+        input_details[1]["index"],
+        tf.constant(text_featurizer.blank, dtype=tf.int32)
+    )
+    tflitemodel.set_tensor(
+        input_details[2]["index"],
+        tf.zeros(
+            [config.model_config["prediction_num_rnns"], 2, 1, config.model_config["prediction_rnn_units"]],
+            dtype=tf.float32
+        )
+    )
+    tflitemodel.invoke()
+    hyp = tflitemodel.get_tensor(output_details[0]["index"])
+
+    print(hyp)
+
+
+if __name__ == '__main__':
+    test_contextnet()


### PR DESCRIPTION
- Fix tflite conversion and interpretation on Transducer's Greedy Decoding, the reason is somehow tflite drops support for `tf.cond` so we have to use `tf.where` instead. Tested on `tensorflow==2.3.1` and `tf-nightly`
- Small update on `BaseTrainer` class: infinity evaluation after training is done, refactor some utility functions